### PR TITLE
Add trading model starter scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,4 +45,12 @@ This script polls Yahoo Finance for the most recent minute data and prints the m
 
 The training script will print classification metrics evaluating how well the model predicts the next-day price movement.
 
+6. Evaluate a saved model on historical data:
+
+```bash
+python scripts/evaluate_model.py apple_model.pkl apple.csv
+```
+
+This script loads the saved model and CSV file and prints accuracy metrics on the known data so you can verify how well the model performs.
+
 This code is intended as a minimal example for experimentation only. Use caution and thoroughly backtest any trading strategy before using it with real funds.

--- a/README.md
+++ b/README.md
@@ -10,17 +10,23 @@ This project provides a simple starting point for experimenting with stock tradi
 pip install -r requirements.txt
 ```
 
-2. Download historical data. For example, to download daily data for Apple:
+2. Download historical data. For example, to download the full history for Apple:
 
 ```bash
-python scripts/data.py AAPL --start 2020-01-01 --output apple.csv
+python scripts/data.py AAPL --start none --output apple.csv
 ```
+
+Passing `--start none` uses the maximum history available from Yahoo Finance. You can also specify a custom start date if you only want recent data.
 
 3. Train a model using the downloaded data:
 
 ```bash
 python scripts/train_model.py apple.csv
 ```
+
+The training script adds a number of technical indicators, including moving averages,
+exponential moving averages, Bollinger Bands, MACD and RSI. These features are used
+as inputs to a RandomForest classifier.
 
 4. Run a simple walk-forward backtest:
 

--- a/README.md
+++ b/README.md
@@ -71,10 +71,10 @@ This backtest uses the trained model's predicted probabilities to trade. The `th
 8. Generate live predictions using the saved model:
 
 ```bash
-python scripts/realtime.py apple_model.pkl AAPL --options options.csv --interval 60
+python scripts/realtime.py apple_model.pkl AAPL --interval 60 --expiration 2025-12-19
 ```
 
-This script polls Yahoo Finance for the most recent minute data and prints the model's prediction each cycle.
+This script polls Yahoo Finance for the most recent minute data and prints the model's prediction each cycle. If you provide `--expiration`, the script will fetch the latest option chain summary on each poll. Alternatively, you can pass `--options` to supply precomputed option features from a CSV file.
 
 The training script will print classification metrics evaluating how well the model predicts the next-day price movement.
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ python scripts/data.py AAPL --start 2020-01-01 --output apple.csv
 python scripts/train_model.py apple.csv
 ```
 
+4. Run a simple walk-forward backtest:
+
+```bash
+python scripts/backtest.py apple.csv
+```
+
 The training script will print classification metrics evaluating how well the model predicts the next-day price movement.
 
 This code is intended as a minimal example for experimentation only. Use caution and thoroughly backtest any trading strategy before using it with real funds.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,27 @@
 # Trading25
-Trading25
-Here is the README, enjoy
+
+This project provides a simple starting point for experimenting with stock trading models. It includes scripts for downloading historical data, generating technical indicators, and training a basic machine learning model.
+
+## Setup
+
+1. Install the required Python packages:
+
+```bash
+pip install -r requirements.txt
+```
+
+2. Download historical data. For example, to download daily data for Apple:
+
+```bash
+python scripts/data.py AAPL --start 2020-01-01 --output apple.csv
+```
+
+3. Train a model using the downloaded data:
+
+```bash
+python scripts/train_model.py apple.csv
+```
+
+The training script will print classification metrics evaluating how well the model predicts the next-day price movement.
+
+This code is intended as a minimal example for experimentation only. Use caution and thoroughly backtest any trading strategy before using it with real funds.

--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@ python scripts/data.py AAPL --start none --output apple.csv
 
 Passing `--start none` uses the maximum history available from Yahoo Finance. You can also specify a custom start date if you only want recent data.
 
-3. Train a model using the downloaded data:
+3. Train a model using the downloaded data and save it for later use:
 
 ```bash
-python scripts/train_model.py apple.csv
+python scripts/train_model.py apple.csv --model-out apple_model.pkl
 ```
 
 The training script adds a number of technical indicators, including moving averages,
@@ -34,6 +34,14 @@ On-Balance Volume. These features are used as inputs to a RandomForest classifie
 ```bash
 python scripts/backtest.py apple.csv
 ```
+
+5. Generate live predictions using the saved model:
+
+```bash
+python scripts/realtime.py apple_model.pkl AAPL --interval 60
+```
+
+This script polls Yahoo Finance for the most recent minute data and prints the model's prediction each cycle.
 
 The training script will print classification metrics evaluating how well the model predicts the next-day price movement.
 

--- a/README.md
+++ b/README.md
@@ -16,18 +16,24 @@ pip install -r requirements.txt
 python scripts/data.py AAPL --start none --output apple.csv
 ```
 
+You can also download a summary of the option chain for a specific expiration date:
+
+```bash
+python scripts/options_data.py AAPL 2025-12-19 --output options.csv
+```
+
 Passing `--start none` uses the maximum history available from Yahoo Finance. You can also specify a custom start date if you only want recent data.
 
 3. Optionally vectorize the data for faster loading:
 
 ```bash
-python scripts/vectorize.py apple.csv --output apple.npz
+python scripts/vectorize.py apple.csv --options options.csv --output apple.npz
 ```
 
 4. Train a model using the downloaded data (CSV or NPZ) and save it for later use:
 
 ```bash
-python scripts/train_model.py apple.csv --model-out apple_model.pkl
+python scripts/train_model.py apple.csv --options options.csv --model-out apple_model.pkl
 
 # or train from the vectorized file
 
@@ -42,7 +48,7 @@ On-Balance Volume. These features are used as inputs to a RandomForest classifie
 5. Optionally tune model hyperparameters with cross-validation:
 
 ```bash
-python scripts/tune_model.py apple.csv
+python scripts/tune_model.py apple.csv --options options.csv
 ```
 
 This script searches several `RandomForestClassifier` settings using a
@@ -51,13 +57,13 @@ time-series split and prints the best parameters found.
 6. Run a simple walk-forward backtest:
 
 ```bash
-python scripts/backtest.py apple.csv
+python scripts/backtest.py apple.csv --options options.csv
 ```
 
 7. Run a configurable backtest using the `backtrader` library:
 
 ```bash
-python scripts/backtrader_backtest.py apple_model.pkl apple.csv --threshold 0.6 --stake 1 --commission 0.001
+python scripts/backtrader_backtest.py apple_model.pkl apple.csv --options options.csv --threshold 0.6 --stake 1 --commission 0.001
 ```
 
 This backtest uses the trained model's predicted probabilities to trade. The `threshold`, `stake`, and `commission` options can be tuned to search for the best return.
@@ -65,7 +71,7 @@ This backtest uses the trained model's predicted probabilities to trade. The `th
 8. Generate live predictions using the saved model:
 
 ```bash
-python scripts/realtime.py apple_model.pkl AAPL --interval 60
+python scripts/realtime.py apple_model.pkl AAPL --options options.csv --interval 60
 ```
 
 This script polls Yahoo Finance for the most recent minute data and prints the model's prediction each cycle.
@@ -75,7 +81,7 @@ The training script will print classification metrics evaluating how well the mo
 9. Evaluate a saved model on historical data:
 
 ```bash
-python scripts/evaluate_model.py apple_model.pkl apple.csv
+python scripts/evaluate_model.py apple_model.pkl apple.csv --options options.csv
 ```
 
 This script loads the saved model and CSV file and prints accuracy metrics on the known data so you can verify how well the model performs.

--- a/README.md
+++ b/README.md
@@ -18,10 +18,20 @@ python scripts/data.py AAPL --start none --output apple.csv
 
 Passing `--start none` uses the maximum history available from Yahoo Finance. You can also specify a custom start date if you only want recent data.
 
-3. Train a model using the downloaded data and save it for later use:
+3. Optionally vectorize the data for faster loading:
+
+```bash
+python scripts/vectorize.py apple.csv --output apple.npz
+```
+
+4. Train a model using the downloaded data (CSV or NPZ) and save it for later use:
 
 ```bash
 python scripts/train_model.py apple.csv --model-out apple_model.pkl
+
+# or train from the vectorized file
+
+python scripts/train_model.py apple.npz --model-out apple_model.pkl
 ```
 
 The training script adds a number of technical indicators, including moving averages,

--- a/README.md
+++ b/README.md
@@ -25,8 +25,9 @@ python scripts/train_model.py apple.csv
 ```
 
 The training script adds a number of technical indicators, including moving averages,
-exponential moving averages, Bollinger Bands, MACD and RSI. These features are used
-as inputs to a RandomForest classifier.
+exponential moving averages, Bollinger Bands, MACD and RSI. It also computes
+Stochastic Oscillator values, Average True Range, Commodity Channel Index and
+On-Balance Volume. These features are used as inputs to a RandomForest classifier.
 
 4. Run a simple walk-forward backtest:
 

--- a/README.md
+++ b/README.md
@@ -39,13 +39,22 @@ exponential moving averages, Bollinger Bands, MACD and RSI. It also computes
 Stochastic Oscillator values, Average True Range, Commodity Channel Index and
 On-Balance Volume. These features are used as inputs to a RandomForest classifier.
 
-5. Run a simple walk-forward backtest:
+5. Optionally tune model hyperparameters with cross-validation:
+
+```bash
+python scripts/tune_model.py apple.csv
+```
+
+This script searches several `RandomForestClassifier` settings using a
+time-series split and prints the best parameters found.
+
+6. Run a simple walk-forward backtest:
 
 ```bash
 python scripts/backtest.py apple.csv
 ```
 
-6. Run a configurable backtest using the `backtrader` library:
+7. Run a configurable backtest using the `backtrader` library:
 
 ```bash
 python scripts/backtrader_backtest.py apple_model.pkl apple.csv --threshold 0.6 --stake 1 --commission 0.001
@@ -53,7 +62,7 @@ python scripts/backtrader_backtest.py apple_model.pkl apple.csv --threshold 0.6 
 
 This backtest uses the trained model's predicted probabilities to trade. The `threshold`, `stake`, and `commission` options can be tuned to search for the best return.
 
-7. Generate live predictions using the saved model:
+8. Generate live predictions using the saved model:
 
 ```bash
 python scripts/realtime.py apple_model.pkl AAPL --interval 60
@@ -63,7 +72,7 @@ This script polls Yahoo Finance for the most recent minute data and prints the m
 
 The training script will print classification metrics evaluating how well the model predicts the next-day price movement.
 
-8. Evaluate a saved model on historical data:
+9. Evaluate a saved model on historical data:
 
 ```bash
 python scripts/evaluate_model.py apple_model.pkl apple.csv

--- a/README.md
+++ b/README.md
@@ -35,7 +35,15 @@ On-Balance Volume. These features are used as inputs to a RandomForest classifie
 python scripts/backtest.py apple.csv
 ```
 
-5. Generate live predictions using the saved model:
+5. Run a configurable backtest using the `backtrader` library:
+
+```bash
+python scripts/backtrader_backtest.py apple_model.pkl apple.csv --threshold 0.6 --stake 1 --commission 0.001
+```
+
+This backtest uses the trained model's predicted probabilities to trade. The `threshold`, `stake`, and `commission` options can be tuned to search for the best return.
+
+6. Generate live predictions using the saved model:
 
 ```bash
 python scripts/realtime.py apple_model.pkl AAPL --interval 60
@@ -45,7 +53,7 @@ This script polls Yahoo Finance for the most recent minute data and prints the m
 
 The training script will print classification metrics evaluating how well the model predicts the next-day price movement.
 
-6. Evaluate a saved model on historical data:
+7. Evaluate a saved model on historical data:
 
 ```bash
 python scripts/evaluate_model.py apple_model.pkl apple.csv

--- a/README.md
+++ b/README.md
@@ -39,13 +39,13 @@ exponential moving averages, Bollinger Bands, MACD and RSI. It also computes
 Stochastic Oscillator values, Average True Range, Commodity Channel Index and
 On-Balance Volume. These features are used as inputs to a RandomForest classifier.
 
-4. Run a simple walk-forward backtest:
+5. Run a simple walk-forward backtest:
 
 ```bash
 python scripts/backtest.py apple.csv
 ```
 
-5. Run a configurable backtest using the `backtrader` library:
+6. Run a configurable backtest using the `backtrader` library:
 
 ```bash
 python scripts/backtrader_backtest.py apple_model.pkl apple.csv --threshold 0.6 --stake 1 --commission 0.001
@@ -53,7 +53,7 @@ python scripts/backtrader_backtest.py apple_model.pkl apple.csv --threshold 0.6 
 
 This backtest uses the trained model's predicted probabilities to trade. The `threshold`, `stake`, and `commission` options can be tuned to search for the best return.
 
-6. Generate live predictions using the saved model:
+7. Generate live predictions using the saved model:
 
 ```bash
 python scripts/realtime.py apple_model.pkl AAPL --interval 60
@@ -63,7 +63,7 @@ This script polls Yahoo Finance for the most recent minute data and prints the m
 
 The training script will print classification metrics evaluating how well the model predicts the next-day price movement.
 
-7. Evaluate a saved model on historical data:
+8. Evaluate a saved model on historical data:
 
 ```bash
 python scripts/evaluate_model.py apple_model.pkl apple.csv

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+yfinance
+pandas
+scikit-learn

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pandas
 scikit-learn
 
 joblib
+backtrader

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 yfinance
 pandas
 scikit-learn
+
+joblib

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 yfinance
 pandas
 scikit-learn
+numpy
 
 joblib
 backtrader

--- a/scripts/backtest.py
+++ b/scripts/backtest.py
@@ -21,7 +21,8 @@ def backtest(csv_path: str) -> float:
         feature_cols = [
             'MA_20', 'MA_50', 'EMA_20', 'EMA_50',
             'BB_Upper', 'BB_Lower', 'MACD', 'MACD_Signal',
-            'RSI_14',
+            'RSI_14', 'Stoch_%K', 'Stoch_%D', 'ATR_14',
+            'CCI_20', 'OBV'
         ]
         model.fit(train_df[feature_cols], train_df['Target'])
         pred = model.predict(test_df[feature_cols])[0]

--- a/scripts/backtest.py
+++ b/scripts/backtest.py
@@ -18,8 +18,13 @@ def backtest(csv_path: str) -> float:
         train_df = df.iloc[:i]
         test_df = df.iloc[i:i+1]
         model = RandomForestClassifier(n_estimators=100, random_state=42)
-        model.fit(train_df[['MA_20', 'MA_50', 'RSI_14']], train_df['Target'])
-        pred = model.predict(test_df[['MA_20', 'MA_50', 'RSI_14']])[0]
+        feature_cols = [
+            'MA_20', 'MA_50', 'EMA_20', 'EMA_50',
+            'BB_Upper', 'BB_Lower', 'MACD', 'MACD_Signal',
+            'RSI_14',
+        ]
+        model.fit(train_df[feature_cols], train_df['Target'])
+        pred = model.predict(test_df[feature_cols])[0]
         predictions.append(pred)
         test_indices.append(test_df.index[0])
 

--- a/scripts/backtest.py
+++ b/scripts/backtest.py
@@ -1,12 +1,15 @@
 import pandas as pd
 from sklearn.ensemble import RandomForestClassifier
-from features import add_technical_indicators
+from features import add_technical_indicators, add_option_features, OPTION_FEATURES
 
 
-def backtest(csv_path: str) -> float:
+def backtest(csv_path: str, options_path: str | None = None) -> float:
     """Run a simple walk-forward backtest and return cumulative return."""
     df = pd.read_csv(csv_path, index_col=0, parse_dates=True)
     df = add_technical_indicators(df)
+    if options_path:
+        opt_df = pd.read_csv(options_path, index_col=0, parse_dates=True)
+        df = add_option_features(df, opt_df)
     df['Target'] = (df['Close'].shift(-1) > df['Close']).astype(int)
     df.dropna(inplace=True)
 
@@ -22,8 +25,8 @@ def backtest(csv_path: str) -> float:
             'MA_20', 'MA_50', 'EMA_20', 'EMA_50',
             'BB_Upper', 'BB_Lower', 'MACD', 'MACD_Signal',
             'RSI_14', 'Stoch_%K', 'Stoch_%D', 'ATR_14',
-            'CCI_20', 'OBV'
-        ]
+            'CCI_20', 'OBV',
+        ] + OPTION_FEATURES
         model.fit(train_df[feature_cols], train_df['Target'])
         pred = model.predict(test_df[feature_cols])[0]
         predictions.append(pred)
@@ -44,6 +47,7 @@ if __name__ == "__main__":
     import argparse
     parser = argparse.ArgumentParser(description="Backtest trading strategy")
     parser.add_argument('csv', help='CSV file with price data')
+    parser.add_argument('--options', help='CSV with option features')
     args = parser.parse_args()
 
-    backtest(args.csv)
+    backtest(args.csv, args.options)

--- a/scripts/backtest.py
+++ b/scripts/backtest.py
@@ -1,0 +1,43 @@
+import pandas as pd
+from sklearn.ensemble import RandomForestClassifier
+from features import add_technical_indicators
+
+
+def backtest(csv_path: str) -> float:
+    """Run a simple walk-forward backtest and return cumulative return."""
+    df = pd.read_csv(csv_path, index_col=0, parse_dates=True)
+    df = add_technical_indicators(df)
+    df['Target'] = (df['Close'].shift(-1) > df['Close']).astype(int)
+    df.dropna(inplace=True)
+
+    prices = df['Close']
+    predictions = []
+    test_indices = []
+
+    for i in range(50, len(df) - 1):
+        train_df = df.iloc[:i]
+        test_df = df.iloc[i:i+1]
+        model = RandomForestClassifier(n_estimators=100, random_state=42)
+        model.fit(train_df[['MA_20', 'MA_50', 'RSI_14']], train_df['Target'])
+        pred = model.predict(test_df[['MA_20', 'MA_50', 'RSI_14']])[0]
+        predictions.append(pred)
+        test_indices.append(test_df.index[0])
+
+    preds = pd.Series(predictions, index=test_indices)
+    returns = prices.pct_change().shift(-1)
+    strategy_returns = returns.loc[preds.index] * preds
+    cumulative_return = (1 + strategy_returns).prod() - 1
+    buy_hold_return = (prices.iloc[len(preds)] / prices.iloc[0]) - 1
+
+    print(f"Strategy cumulative return: {cumulative_return:.2%}")
+    print(f"Buy and hold return: {buy_hold_return:.2%}")
+    return cumulative_return
+
+
+if __name__ == "__main__":
+    import argparse
+    parser = argparse.ArgumentParser(description="Backtest trading strategy")
+    parser.add_argument('csv', help='CSV file with price data')
+    args = parser.parse_args()
+
+    backtest(args.csv)

--- a/scripts/backtrader_backtest.py
+++ b/scripts/backtrader_backtest.py
@@ -2,14 +2,14 @@ import argparse
 import joblib
 import pandas as pd
 import backtrader as bt
-from features import add_technical_indicators
+from features import add_technical_indicators, add_option_features, OPTION_FEATURES
 
 FEATURE_COLS = [
     'MA_20', 'MA_50', 'EMA_20', 'EMA_50',
     'BB_Upper', 'BB_Lower', 'MACD', 'MACD_Signal',
     'RSI_14', 'Stoch_%K', 'Stoch_%D', 'ATR_14',
-    'CCI_20', 'OBV'
-]
+    'CCI_20', 'OBV',
+] + OPTION_FEATURES
 
 class ModelStrategy(bt.Strategy):
     params = dict(threshold=0.6, stake=1.0)
@@ -24,9 +24,12 @@ class ModelStrategy(bt.Strategy):
         elif self.position and p <= self.p.threshold:
             self.close()
 
-def run_backtest(csv_path: str, model_path: str, threshold: float, stake: float, commission: float):
+def run_backtest(csv_path: str, model_path: str, threshold: float, stake: float, commission: float, options_path: str | None = None):
     df = pd.read_csv(csv_path, index_col=0, parse_dates=True)
     df = add_technical_indicators(df)
+    if options_path:
+        opt_df = pd.read_csv(options_path, index_col=0, parse_dates=True)
+        df = add_option_features(df, opt_df)
     df.dropna(inplace=True)
 
     model = joblib.load(model_path)
@@ -54,9 +57,10 @@ def main():
     parser.add_argument('--threshold', type=float, default=0.6, help='Buy probability threshold')
     parser.add_argument('--stake', type=float, default=1.0, help='Trade size per order')
     parser.add_argument('--commission', type=float, default=0.0, help='Broker commission as decimal')
+    parser.add_argument('--options', help='CSV with option features')
     args = parser.parse_args()
 
-    run_backtest(args.csv, args.model, args.threshold, args.stake, args.commission)
+    run_backtest(args.csv, args.model, args.threshold, args.stake, args.commission, args.options)
 
 if __name__ == '__main__':
     main()

--- a/scripts/backtrader_backtest.py
+++ b/scripts/backtrader_backtest.py
@@ -1,0 +1,62 @@
+import argparse
+import joblib
+import pandas as pd
+import backtrader as bt
+from features import add_technical_indicators
+
+FEATURE_COLS = [
+    'MA_20', 'MA_50', 'EMA_20', 'EMA_50',
+    'BB_Upper', 'BB_Lower', 'MACD', 'MACD_Signal',
+    'RSI_14', 'Stoch_%K', 'Stoch_%D', 'ATR_14',
+    'CCI_20', 'OBV'
+]
+
+class ModelStrategy(bt.Strategy):
+    params = dict(threshold=0.6, stake=1.0)
+
+    def __init__(self):
+        self.prob = self.datas[0].prob
+
+    def next(self):
+        p = self.prob[0]
+        if not self.position and p > self.p.threshold:
+            self.buy(size=self.p.stake)
+        elif self.position and p <= self.p.threshold:
+            self.close()
+
+def run_backtest(csv_path: str, model_path: str, threshold: float, stake: float, commission: float):
+    df = pd.read_csv(csv_path, index_col=0, parse_dates=True)
+    df = add_technical_indicators(df)
+    df.dropna(inplace=True)
+
+    model = joblib.load(model_path)
+    probs = model.predict_proba(df[FEATURE_COLS])[:, 1]
+    df['prob'] = probs
+
+    data = bt.feeds.PandasData(dataname=df)
+    cerebro = bt.Cerebro()
+    cerebro.adddata(data)
+    cerebro.addstrategy(ModelStrategy, threshold=threshold, stake=stake)
+    cerebro.broker.setcash(10000.0)
+    cerebro.broker.setcommission(commission=commission)
+
+    start_val = cerebro.broker.getvalue()
+    cerebro.run()
+    end_val = cerebro.broker.getvalue()
+    print(f"Starting portfolio value: {start_val:.2f}")
+    print(f"Final portfolio value: {end_val:.2f}")
+    print(f"Return: {(end_val / start_val - 1) * 100:.2f}%")
+
+def main():
+    parser = argparse.ArgumentParser(description="Backtest model with backtrader")
+    parser.add_argument('model', help='Trained model file')
+    parser.add_argument('csv', help='CSV with historical data')
+    parser.add_argument('--threshold', type=float, default=0.6, help='Buy probability threshold')
+    parser.add_argument('--stake', type=float, default=1.0, help='Trade size per order')
+    parser.add_argument('--commission', type=float, default=0.0, help='Broker commission as decimal')
+    args = parser.parse_args()
+
+    run_backtest(args.csv, args.model, args.threshold, args.stake, args.commission)
+
+if __name__ == '__main__':
+    main()

--- a/scripts/data.py
+++ b/scripts/data.py
@@ -1,0 +1,26 @@
+import yfinance as yf
+import pandas as pd
+
+
+def download_data(ticker: str, start: str, end: str) -> pd.DataFrame:
+    """Download historical OHLCV data for a given ticker."""
+    data = yf.download(ticker, start=start, end=end)
+    return data
+
+
+def main():
+    import argparse
+    parser = argparse.ArgumentParser(description="Download historical data")
+    parser.add_argument("ticker", help="Ticker symbol to download")
+    parser.add_argument("--start", default="2020-01-01", help="Start date YYYY-MM-DD")
+    parser.add_argument("--end", default=None, help="End date YYYY-MM-DD")
+    parser.add_argument("--output", default="data.csv", help="File to save data")
+    args = parser.parse_args()
+
+    df = download_data(args.ticker, args.start, args.end)
+    df.to_csv(args.output)
+    print(f"Saved {len(df)} rows to {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/data.py
+++ b/scripts/data.py
@@ -2,9 +2,12 @@ import yfinance as yf
 import pandas as pd
 
 
-def download_data(ticker: str, start: str, end: str) -> pd.DataFrame:
+def download_data(ticker: str, start: str | None, end: str | None) -> pd.DataFrame:
     """Download historical OHLCV data for a given ticker."""
-    data = yf.download(ticker, start=start, end=end)
+    if start is None:
+        data = yf.download(ticker, period="max")
+    else:
+        data = yf.download(ticker, start=start, end=end)
     return data
 
 
@@ -12,12 +15,14 @@ def main():
     import argparse
     parser = argparse.ArgumentParser(description="Download historical data")
     parser.add_argument("ticker", help="Ticker symbol to download")
-    parser.add_argument("--start", default="2020-01-01", help="Start date YYYY-MM-DD")
+    parser.add_argument("--start", default="1980-01-01", help="Start date YYYY-MM-DD, use none for full history")
     parser.add_argument("--end", default=None, help="End date YYYY-MM-DD")
     parser.add_argument("--output", default="data.csv", help="File to save data")
     args = parser.parse_args()
 
-    df = download_data(args.ticker, args.start, args.end)
+    start = None if args.start and args.start.lower() == 'none' else args.start
+    end = None if args.end and args.end.lower() == 'none' else args.end
+    df = download_data(args.ticker, start, end)
     df.to_csv(args.output)
     print(f"Saved {len(df)} rows to {args.output}")
 

--- a/scripts/evaluate_model.py
+++ b/scripts/evaluate_model.py
@@ -1,0 +1,44 @@
+import argparse
+import joblib
+import pandas as pd
+from sklearn.metrics import classification_report, accuracy_score
+from features import add_technical_indicators
+
+FEATURE_COLS = [
+    'MA_20', 'MA_50', 'EMA_20', 'EMA_50',
+    'BB_Upper', 'BB_Lower', 'MACD', 'MACD_Signal',
+    'RSI_14', 'Stoch_%K', 'Stoch_%D', 'ATR_14',
+    'CCI_20', 'OBV'
+]
+
+def load_dataset(csv_path: str) -> pd.DataFrame:
+    df = pd.read_csv(csv_path, index_col=0, parse_dates=True)
+    df = add_technical_indicators(df)
+    df['Target'] = (df['Close'].shift(-1) > df['Close']).astype(int)
+    df.dropna(inplace=True)
+    return df
+
+
+def evaluate(model_path: str, df: pd.DataFrame) -> float:
+    model = joblib.load(model_path)
+    X = df[FEATURE_COLS]
+    y = df['Target']
+    preds = model.predict(X)
+    acc = accuracy_score(y, preds)
+    print(classification_report(y, preds))
+    print(f"Accuracy: {acc:.2%}")
+    return acc
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Evaluate trained model on historical data")
+    parser.add_argument('model', help='Path to saved model')
+    parser.add_argument('csv', help='CSV file with historical price data')
+    args = parser.parse_args()
+
+    df = load_dataset(args.csv)
+    evaluate(args.model, df)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/evaluate_model.py
+++ b/scripts/evaluate_model.py
@@ -2,18 +2,21 @@ import argparse
 import joblib
 import pandas as pd
 from sklearn.metrics import classification_report, accuracy_score
-from features import add_technical_indicators
+from features import add_technical_indicators, add_option_features, OPTION_FEATURES
 
 FEATURE_COLS = [
     'MA_20', 'MA_50', 'EMA_20', 'EMA_50',
     'BB_Upper', 'BB_Lower', 'MACD', 'MACD_Signal',
     'RSI_14', 'Stoch_%K', 'Stoch_%D', 'ATR_14',
-    'CCI_20', 'OBV'
-]
+    'CCI_20', 'OBV',
+] + OPTION_FEATURES
 
-def load_dataset(csv_path: str) -> pd.DataFrame:
+def load_dataset(csv_path: str, options_path: str | None = None) -> pd.DataFrame:
     df = pd.read_csv(csv_path, index_col=0, parse_dates=True)
     df = add_technical_indicators(df)
+    if options_path:
+        opt_df = pd.read_csv(options_path, index_col=0, parse_dates=True)
+        df = add_option_features(df, opt_df)
     df['Target'] = (df['Close'].shift(-1) > df['Close']).astype(int)
     df.dropna(inplace=True)
     return df
@@ -34,9 +37,10 @@ def main():
     parser = argparse.ArgumentParser(description="Evaluate trained model on historical data")
     parser.add_argument('model', help='Path to saved model')
     parser.add_argument('csv', help='CSV file with historical price data')
+    parser.add_argument('--options', help='CSV with option features')
     args = parser.parse_args()
 
-    df = load_dataset(args.csv)
+    df = load_dataset(args.csv, args.options)
     evaluate(args.model, df)
 
 

--- a/scripts/features.py
+++ b/scripts/features.py
@@ -45,6 +45,20 @@ def add_technical_indicators(df: pd.DataFrame) -> pd.DataFrame:
     return df
 
 
+OPTION_FEATURES = [
+    "CallVolume", "PutVolume", "CallOI", "PutOI", "CallIV", "PutIV"
+]
+
+
+def add_option_features(df: pd.DataFrame, opt_df: pd.DataFrame) -> pd.DataFrame:
+    """Merge option-based features into the price dataframe."""
+    opt_df = opt_df.copy()
+    opt_df.index = pd.to_datetime(opt_df.index)
+    df = df.join(opt_df[OPTION_FEATURES], how="left")
+    df[OPTION_FEATURES] = df[OPTION_FEATURES].fillna(method="ffill")
+    return df
+
+
 def compute_rsi(series: pd.Series, window: int = 14) -> pd.Series:
     delta = series.diff()
     gain = (delta.where(delta > 0, 0)).rolling(window=window).mean()

--- a/scripts/features.py
+++ b/scripts/features.py
@@ -2,11 +2,31 @@ import pandas as pd
 
 
 def add_technical_indicators(df: pd.DataFrame) -> pd.DataFrame:
-    """Add some basic technical indicators to the dataframe."""
+    """Add several common technical indicators to the dataframe."""
     df = df.copy()
-    df['MA_20'] = df['Close'].rolling(window=20).mean()
-    df['MA_50'] = df['Close'].rolling(window=50).mean()
-    df['RSI_14'] = compute_rsi(df['Close'], window=14)
+
+    # Simple moving averages
+    df["MA_20"] = df["Close"].rolling(window=20).mean()
+    df["MA_50"] = df["Close"].rolling(window=50).mean()
+
+    # Exponential moving averages
+    df["EMA_20"] = df["Close"].ewm(span=20, adjust=False).mean()
+    df["EMA_50"] = df["Close"].ewm(span=50, adjust=False).mean()
+
+    # Bollinger Bands
+    mid = df["Close"].rolling(window=20).mean()
+    std = df["Close"].rolling(window=20).std()
+    df["BB_Upper"] = mid + 2 * std
+    df["BB_Lower"] = mid - 2 * std
+
+    # MACD and signal line
+    ema12 = df["Close"].ewm(span=12, adjust=False).mean()
+    ema26 = df["Close"].ewm(span=26, adjust=False).mean()
+    df["MACD"] = ema12 - ema26
+    df["MACD_Signal"] = df["MACD"].ewm(span=9, adjust=False).mean()
+
+    df["RSI_14"] = compute_rsi(df["Close"], window=14)
+
     return df
 
 

--- a/scripts/features.py
+++ b/scripts/features.py
@@ -1,0 +1,20 @@
+import pandas as pd
+
+
+def add_technical_indicators(df: pd.DataFrame) -> pd.DataFrame:
+    """Add some basic technical indicators to the dataframe."""
+    df = df.copy()
+    df['MA_20'] = df['Close'].rolling(window=20).mean()
+    df['MA_50'] = df['Close'].rolling(window=50).mean()
+    df['RSI_14'] = compute_rsi(df['Close'], window=14)
+    return df
+
+
+def compute_rsi(series: pd.Series, window: int = 14) -> pd.Series:
+    delta = series.diff()
+    gain = (delta.where(delta > 0, 0)).rolling(window=window).mean()
+    loss = (-delta.where(delta < 0, 0)).rolling(window=window).mean()
+    rs = gain / loss
+    rsi = 100 - (100 / (1 + rs))
+    return rsi
+

--- a/scripts/features.py
+++ b/scripts/features.py
@@ -1,4 +1,5 @@
 import pandas as pd
+import numpy as np
 
 
 def add_technical_indicators(df: pd.DataFrame) -> pd.DataFrame:
@@ -27,6 +28,20 @@ def add_technical_indicators(df: pd.DataFrame) -> pd.DataFrame:
 
     df["RSI_14"] = compute_rsi(df["Close"], window=14)
 
+    # Stochastic Oscillator
+    stoch_k, stoch_d = compute_stochastic(df, window=14)
+    df["Stoch_%K"] = stoch_k
+    df["Stoch_%D"] = stoch_d
+
+    # Average True Range
+    df["ATR_14"] = compute_atr(df, window=14)
+
+    # Commodity Channel Index
+    df["CCI_20"] = compute_cci(df, window=20)
+
+    # On-Balance Volume
+    df["OBV"] = compute_obv(df)
+
     return df
 
 
@@ -37,4 +52,42 @@ def compute_rsi(series: pd.Series, window: int = 14) -> pd.Series:
     rs = gain / loss
     rsi = 100 - (100 / (1 + rs))
     return rsi
+
+
+def compute_stochastic(df: pd.DataFrame, window: int = 14) -> tuple[pd.Series, pd.Series]:
+    """Return %K and %D stochastic oscillator series."""
+    low_min = df["Low"].rolling(window=window).min()
+    high_max = df["High"].rolling(window=window).max()
+    percent_k = (df["Close"] - low_min) / (high_max - low_min) * 100
+    percent_d = percent_k.rolling(window=3).mean()
+    return percent_k, percent_d
+
+
+def compute_atr(df: pd.DataFrame, window: int = 14) -> pd.Series:
+    high_low = df["High"] - df["Low"]
+    high_close = (df["High"] - df["Close"].shift()).abs()
+    low_close = (df["Low"] - df["Close"].shift()).abs()
+    tr = pd.concat([high_low, high_close, low_close], axis=1).max(axis=1)
+    atr = tr.rolling(window=window).mean()
+    return atr
+
+
+def compute_cci(df: pd.DataFrame, window: int = 20) -> pd.Series:
+    tp = (df["High"] + df["Low"] + df["Close"]) / 3
+    sma = tp.rolling(window=window).mean()
+    mad = tp.rolling(window=window).apply(lambda x: np.mean(np.abs(x - x.mean())), raw=True)
+    cci = (tp - sma) / (0.015 * mad)
+    return cci
+
+
+def compute_obv(df: pd.DataFrame) -> pd.Series:
+    obv = [0]
+    for i in range(1, len(df)):
+        if df["Close"].iloc[i] > df["Close"].iloc[i - 1]:
+            obv.append(obv[-1] + df["Volume"].iloc[i])
+        elif df["Close"].iloc[i] < df["Close"].iloc[i - 1]:
+            obv.append(obv[-1] - df["Volume"].iloc[i])
+        else:
+            obv.append(obv[-1])
+    return pd.Series(obv, index=df.index)
 

--- a/scripts/options_data.py
+++ b/scripts/options_data.py
@@ -6,8 +6,19 @@ OPTION_COLS = [
     "CallVolume", "PutVolume", "CallOI", "PutOI", "CallIV", "PutIV"
 ]
 
-def fetch_options_summary(ticker: str, expiration: str) -> pd.DataFrame:
+
+def get_nearest_expiration(ticker: str) -> str:
+    """Return the nearest expiration date available for the ticker."""
+    t = yf.Ticker(ticker)
+    expirations = t.options
+    if not expirations:
+        raise ValueError(f"No option expirations found for {ticker}")
+    return expirations[0]
+
+def fetch_options_summary(ticker: str, expiration: str | None = None) -> pd.DataFrame:
     """Fetch option chain summary for a single expiration date."""
+    if expiration is None:
+        expiration = get_nearest_expiration(ticker)
     t = yf.Ticker(ticker)
     chain = t.option_chain(expiration)
     calls = chain.calls
@@ -27,7 +38,7 @@ def fetch_options_summary(ticker: str, expiration: str) -> pd.DataFrame:
 def main():
     parser = argparse.ArgumentParser(description="Download option chain summary")
     parser.add_argument("ticker", help="Underlying ticker")
-    parser.add_argument("expiration", help="Expiration date YYYY-MM-DD")
+    parser.add_argument("--expiration", help="Expiration date YYYY-MM-DD (default nearest)")
     parser.add_argument("--output", default="options.csv", help="Output CSV file")
     args = parser.parse_args()
 

--- a/scripts/options_data.py
+++ b/scripts/options_data.py
@@ -1,0 +1,39 @@
+import argparse
+import pandas as pd
+import yfinance as yf
+
+OPTION_COLS = [
+    "CallVolume", "PutVolume", "CallOI", "PutOI", "CallIV", "PutIV"
+]
+
+def fetch_options_summary(ticker: str, expiration: str) -> pd.DataFrame:
+    """Fetch option chain summary for a single expiration date."""
+    t = yf.Ticker(ticker)
+    chain = t.option_chain(expiration)
+    calls = chain.calls
+    puts = chain.puts
+    data = {
+        "CallVolume": calls["volume"].sum(),
+        "PutVolume": puts["volume"].sum(),
+        "CallOI": calls["openInterest"].sum(),
+        "PutOI": puts["openInterest"].sum(),
+        "CallIV": calls["impliedVolatility"].mean(),
+        "PutIV": puts["impliedVolatility"].mean(),
+    }
+    df = pd.DataFrame([data])
+    df.index = [pd.to_datetime("today").normalize()]
+    return df
+
+def main():
+    parser = argparse.ArgumentParser(description="Download option chain summary")
+    parser.add_argument("ticker", help="Underlying ticker")
+    parser.add_argument("expiration", help="Expiration date YYYY-MM-DD")
+    parser.add_argument("--output", default="options.csv", help="Output CSV file")
+    args = parser.parse_args()
+
+    df = fetch_options_summary(args.ticker, args.expiration)
+    df.to_csv(args.output)
+    print(f"Saved option summary to {args.output}")
+
+if __name__ == "__main__":
+    main()

--- a/scripts/realtime.py
+++ b/scripts/realtime.py
@@ -3,26 +3,29 @@ import time
 import joblib
 import pandas as pd
 import yfinance as yf
-from features import add_technical_indicators
+from features import add_technical_indicators, add_option_features, OPTION_FEATURES
 
 FEATURE_COLS = [
     'MA_20', 'MA_50', 'EMA_20', 'EMA_50',
     'BB_Upper', 'BB_Lower', 'MACD', 'MACD_Signal',
     'RSI_14', 'Stoch_%K', 'Stoch_%D', 'ATR_14',
-    'CCI_20', 'OBV'
-]
+    'CCI_20', 'OBV',
+] + OPTION_FEATURES
 
 def fetch_recent_data(ticker: str, period: str = "60d", interval: str = "1m") -> pd.DataFrame:
     """Fetch recent intraday data for the given ticker."""
     df = yf.download(ticker, period=period, interval=interval, progress=False)
     return df
 
-def run(model_path: str, ticker: str, poll_interval: int) -> None:
+def run(model_path: str, ticker: str, poll_interval: int, options_path: str | None = None) -> None:
     model = joblib.load(model_path)
     print(f"Loaded model from {model_path}. Polling {ticker} every {poll_interval}s...")
     while True:
         df = fetch_recent_data(ticker)
         df = add_technical_indicators(df)
+        if options_path:
+            opt_df = pd.read_csv(options_path, index_col=0, parse_dates=True)
+            df = add_option_features(df, opt_df)
         df.dropna(inplace=True)
         latest = df.iloc[-1:]
         features = latest[FEATURE_COLS]
@@ -38,8 +41,9 @@ def main():
     parser.add_argument("model", help="Trained model file")
     parser.add_argument("ticker", help="Ticker symbol to monitor")
     parser.add_argument("--interval", type=int, default=60, help="Polling interval in seconds")
+    parser.add_argument("--options", help="CSV with option features")
     args = parser.parse_args()
-    run(args.model, args.ticker, args.interval)
+    run(args.model, args.ticker, args.interval, args.options)
 
 
 if __name__ == "__main__":

--- a/scripts/realtime.py
+++ b/scripts/realtime.py
@@ -1,0 +1,46 @@
+import argparse
+import time
+import joblib
+import pandas as pd
+import yfinance as yf
+from features import add_technical_indicators
+
+FEATURE_COLS = [
+    'MA_20', 'MA_50', 'EMA_20', 'EMA_50',
+    'BB_Upper', 'BB_Lower', 'MACD', 'MACD_Signal',
+    'RSI_14', 'Stoch_%K', 'Stoch_%D', 'ATR_14',
+    'CCI_20', 'OBV'
+]
+
+def fetch_recent_data(ticker: str, period: str = "60d", interval: str = "1m") -> pd.DataFrame:
+    """Fetch recent intraday data for the given ticker."""
+    df = yf.download(ticker, period=period, interval=interval, progress=False)
+    return df
+
+def run(model_path: str, ticker: str, poll_interval: int) -> None:
+    model = joblib.load(model_path)
+    print(f"Loaded model from {model_path}. Polling {ticker} every {poll_interval}s...")
+    while True:
+        df = fetch_recent_data(ticker)
+        df = add_technical_indicators(df)
+        df.dropna(inplace=True)
+        latest = df.iloc[-1:]
+        features = latest[FEATURE_COLS]
+        pred = model.predict(features)[0]
+        direction = "UP" if pred == 1 else "DOWN"
+        timestamp = latest.index[-1]
+        print(f"{timestamp} prediction: {direction}")
+        time.sleep(poll_interval)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Run real-time predictions")
+    parser.add_argument("model", help="Trained model file")
+    parser.add_argument("ticker", help="Ticker symbol to monitor")
+    parser.add_argument("--interval", type=int, default=60, help="Polling interval in seconds")
+    args = parser.parse_args()
+    run(args.model, args.ticker, args.interval)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/realtime.py
+++ b/scripts/realtime.py
@@ -4,6 +4,7 @@ import joblib
 import pandas as pd
 import yfinance as yf
 from features import add_technical_indicators, add_option_features, OPTION_FEATURES
+from options_data import fetch_options_summary
 
 FEATURE_COLS = [
     'MA_20', 'MA_50', 'EMA_20', 'EMA_50',
@@ -17,7 +18,7 @@ def fetch_recent_data(ticker: str, period: str = "60d", interval: str = "1m") ->
     df = yf.download(ticker, period=period, interval=interval, progress=False)
     return df
 
-def run(model_path: str, ticker: str, poll_interval: int, options_path: str | None = None) -> None:
+def run(model_path: str, ticker: str, poll_interval: int, options_path: str | None = None, expiration: str | None = None) -> None:
     model = joblib.load(model_path)
     print(f"Loaded model from {model_path}. Polling {ticker} every {poll_interval}s...")
     while True:
@@ -25,6 +26,10 @@ def run(model_path: str, ticker: str, poll_interval: int, options_path: str | No
         df = add_technical_indicators(df)
         if options_path:
             opt_df = pd.read_csv(options_path, index_col=0, parse_dates=True)
+            df = add_option_features(df, opt_df)
+        elif expiration:
+            opt_df = fetch_options_summary(ticker, expiration)
+            opt_df.index = [df.index[-1]]
             df = add_option_features(df, opt_df)
         df.dropna(inplace=True)
         latest = df.iloc[-1:]
@@ -42,8 +47,9 @@ def main():
     parser.add_argument("ticker", help="Ticker symbol to monitor")
     parser.add_argument("--interval", type=int, default=60, help="Polling interval in seconds")
     parser.add_argument("--options", help="CSV with option features")
+    parser.add_argument("--expiration", help="Fetch option summary for this expiration date")
     args = parser.parse_args()
-    run(args.model, args.ticker, args.interval, args.options)
+    run(args.model, args.ticker, args.interval, args.options, args.expiration)
 
 
 if __name__ == "__main__":

--- a/scripts/train_model.py
+++ b/scripts/train_model.py
@@ -4,13 +4,23 @@ from sklearn.ensemble import RandomForestClassifier
 from sklearn.model_selection import train_test_split
 from sklearn.metrics import classification_report
 import joblib
-from features import add_technical_indicators
+from features import add_technical_indicators, add_option_features, OPTION_FEATURES
+
+FEATURE_COLS = [
+    'MA_20', 'MA_50', 'EMA_20', 'EMA_50',
+    'BB_Upper', 'BB_Lower', 'MACD', 'MACD_Signal',
+    'RSI_14', 'Stoch_%K', 'Stoch_%D', 'ATR_14',
+    'CCI_20', 'OBV',
+] + OPTION_FEATURES
 
 
-def prepare_dataset(csv_path: str) -> pd.DataFrame:
-    """Load price data from csv and add features and target."""
+def prepare_dataset(csv_path: str, options_path: str | None = None) -> pd.DataFrame:
+    """Load price data from csv, optional options data, and add features and target."""
     df = pd.read_csv(csv_path, index_col=0, parse_dates=True)
     df = add_technical_indicators(df)
+    if options_path:
+        opt_df = pd.read_csv(options_path, index_col=0, parse_dates=True)
+        df = add_option_features(df, opt_df)
     df['Target'] = (df['Close'].shift(-1) > df['Close']).astype(int)
     df.dropna(inplace=True)
     return df
@@ -22,13 +32,7 @@ def load_npz_dataset(npz_path: str) -> tuple[np.ndarray, np.ndarray]:
 
 
 def train(df: pd.DataFrame) -> RandomForestClassifier:
-    feature_cols = [
-        'MA_20', 'MA_50', 'EMA_20', 'EMA_50',
-        'BB_Upper', 'BB_Lower', 'MACD', 'MACD_Signal',
-        'RSI_14', 'Stoch_%K', 'Stoch_%D', 'ATR_14',
-        'CCI_20', 'OBV'
-    ]
-    X = df[feature_cols]
+    X = df[[c for c in FEATURE_COLS if c in df.columns]]
     y = df['Target']
     X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.3, shuffle=False)
 
@@ -52,6 +56,7 @@ def main():
     import argparse
     parser = argparse.ArgumentParser(description="Train trading model")
     parser.add_argument('data', help='CSV or NPZ dataset')
+    parser.add_argument('--options', help='CSV file with option features')
     parser.add_argument('--model-out', default='model.pkl', help='File to save trained model')
     args = parser.parse_args()
 
@@ -59,7 +64,7 @@ def main():
         X, y = load_npz_dataset(args.data)
         model = train_arrays(X, y)
     else:
-        df = prepare_dataset(args.data)
+        df = prepare_dataset(args.data, args.options)
         model = train(df)
 
     joblib.dump(model, args.model_out)

--- a/scripts/train_model.py
+++ b/scripts/train_model.py
@@ -1,0 +1,40 @@
+import pandas as pd
+from sklearn.ensemble import RandomForestClassifier
+from sklearn.model_selection import train_test_split
+from sklearn.metrics import classification_report
+from features import add_technical_indicators
+
+
+def prepare_dataset(csv_path: str) -> pd.DataFrame:
+    """Load price data from csv and add features and target."""
+    df = pd.read_csv(csv_path, index_col=0, parse_dates=True)
+    df = add_technical_indicators(df)
+    df['Target'] = (df['Close'].shift(-1) > df['Close']).astype(int)
+    df.dropna(inplace=True)
+    return df
+
+
+def train(df: pd.DataFrame):
+    X = df[['MA_20', 'MA_50', 'RSI_14']]
+    y = df['Target']
+    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.3, shuffle=False)
+
+    model = RandomForestClassifier(n_estimators=100, random_state=42)
+    model.fit(X_train, y_train)
+    preds = model.predict(X_test)
+    print(classification_report(y_test, preds))
+    return model
+
+
+def main():
+    import argparse
+    parser = argparse.ArgumentParser(description="Train trading model")
+    parser.add_argument('csv', help='CSV file with price data')
+    args = parser.parse_args()
+
+    df = prepare_dataset(args.csv)
+    train(df)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/train_model.py
+++ b/scripts/train_model.py
@@ -15,7 +15,12 @@ def prepare_dataset(csv_path: str) -> pd.DataFrame:
 
 
 def train(df: pd.DataFrame):
-    X = df[['MA_20', 'MA_50', 'RSI_14']]
+    feature_cols = [
+        'MA_20', 'MA_50', 'EMA_20', 'EMA_50',
+        'BB_Upper', 'BB_Lower', 'MACD', 'MACD_Signal',
+        'RSI_14',
+    ]
+    X = df[feature_cols]
     y = df['Target']
     X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.3, shuffle=False)
 

--- a/scripts/train_model.py
+++ b/scripts/train_model.py
@@ -1,4 +1,5 @@
 import pandas as pd
+import numpy as np
 from sklearn.ensemble import RandomForestClassifier
 from sklearn.model_selection import train_test_split
 from sklearn.metrics import classification_report
@@ -13,6 +14,11 @@ def prepare_dataset(csv_path: str) -> pd.DataFrame:
     df['Target'] = (df['Close'].shift(-1) > df['Close']).astype(int)
     df.dropna(inplace=True)
     return df
+
+
+def load_npz_dataset(npz_path: str) -> tuple[np.ndarray, np.ndarray]:
+    data = np.load(npz_path)
+    return data['X'], data['y']
 
 
 def train(df: pd.DataFrame) -> RandomForestClassifier:
@@ -33,15 +39,29 @@ def train(df: pd.DataFrame) -> RandomForestClassifier:
     return model
 
 
+def train_arrays(X: np.ndarray, y: np.ndarray) -> RandomForestClassifier:
+    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.3, shuffle=False)
+    model = RandomForestClassifier(n_estimators=100, random_state=42)
+    model.fit(X_train, y_train)
+    preds = model.predict(X_test)
+    print(classification_report(y_test, preds))
+    return model
+
+
 def main():
     import argparse
     parser = argparse.ArgumentParser(description="Train trading model")
-    parser.add_argument('csv', help='CSV file with price data')
+    parser.add_argument('data', help='CSV or NPZ dataset')
     parser.add_argument('--model-out', default='model.pkl', help='File to save trained model')
     args = parser.parse_args()
 
-    df = prepare_dataset(args.csv)
-    model = train(df)
+    if args.data.lower().endswith('.npz'):
+        X, y = load_npz_dataset(args.data)
+        model = train_arrays(X, y)
+    else:
+        df = prepare_dataset(args.data)
+        model = train(df)
+
     joblib.dump(model, args.model_out)
     print(f"Saved model to {args.model_out}")
 

--- a/scripts/train_model.py
+++ b/scripts/train_model.py
@@ -2,6 +2,7 @@ import pandas as pd
 from sklearn.ensemble import RandomForestClassifier
 from sklearn.model_selection import train_test_split
 from sklearn.metrics import classification_report
+import joblib
 from features import add_technical_indicators
 
 
@@ -14,7 +15,7 @@ def prepare_dataset(csv_path: str) -> pd.DataFrame:
     return df
 
 
-def train(df: pd.DataFrame):
+def train(df: pd.DataFrame) -> RandomForestClassifier:
     feature_cols = [
         'MA_20', 'MA_50', 'EMA_20', 'EMA_50',
         'BB_Upper', 'BB_Lower', 'MACD', 'MACD_Signal',
@@ -36,10 +37,13 @@ def main():
     import argparse
     parser = argparse.ArgumentParser(description="Train trading model")
     parser.add_argument('csv', help='CSV file with price data')
+    parser.add_argument('--model-out', default='model.pkl', help='File to save trained model')
     args = parser.parse_args()
 
     df = prepare_dataset(args.csv)
-    train(df)
+    model = train(df)
+    joblib.dump(model, args.model_out)
+    print(f"Saved model to {args.model_out}")
 
 
 if __name__ == "__main__":

--- a/scripts/train_model.py
+++ b/scripts/train_model.py
@@ -18,7 +18,8 @@ def train(df: pd.DataFrame):
     feature_cols = [
         'MA_20', 'MA_50', 'EMA_20', 'EMA_50',
         'BB_Upper', 'BB_Lower', 'MACD', 'MACD_Signal',
-        'RSI_14',
+        'RSI_14', 'Stoch_%K', 'Stoch_%D', 'ATR_14',
+        'CCI_20', 'OBV'
     ]
     X = df[feature_cols]
     y = df['Target']

--- a/scripts/tune_model.py
+++ b/scripts/tune_model.py
@@ -4,18 +4,21 @@ import pandas as pd
 from sklearn.ensemble import RandomForestClassifier
 from sklearn.model_selection import GridSearchCV, TimeSeriesSplit
 import joblib
-from features import add_technical_indicators
+from features import add_technical_indicators, add_option_features, OPTION_FEATURES
 
 FEATURE_COLS = [
     'MA_20', 'MA_50', 'EMA_20', 'EMA_50',
     'BB_Upper', 'BB_Lower', 'MACD', 'MACD_Signal',
     'RSI_14', 'Stoch_%K', 'Stoch_%D', 'ATR_14',
-    'CCI_20', 'OBV'
-]
+    'CCI_20', 'OBV',
+] + OPTION_FEATURES
 
-def load_csv(csv_path: str) -> tuple[np.ndarray, np.ndarray]:
+def load_csv(csv_path: str, options_path: str | None = None) -> tuple[np.ndarray, np.ndarray]:
     df = pd.read_csv(csv_path, index_col=0, parse_dates=True)
     df = add_technical_indicators(df)
+    if options_path:
+        opt_df = pd.read_csv(options_path, index_col=0, parse_dates=True)
+        df = add_option_features(df, opt_df)
     df['Target'] = (df['Close'].shift(-1) > df['Close']).astype(int)
     df.dropna(inplace=True)
     X = df[FEATURE_COLS]
@@ -26,11 +29,11 @@ def load_npz(npz_path: str) -> tuple[np.ndarray, np.ndarray]:
     data = np.load(npz_path)
     return data['X'], data['y']
 
-def tune(dataset: str, save_path: str | None = None) -> None:
+def tune(dataset: str, save_path: str | None = None, options_path: str | None = None) -> None:
     if dataset.lower().endswith('.npz'):
         X, y = load_npz(dataset)
     else:
-        X, y = load_csv(dataset)
+        X, y = load_csv(dataset, options_path)
 
     param_grid = {
         'n_estimators': [100, 200],
@@ -52,8 +55,9 @@ def main():
     parser = argparse.ArgumentParser(description="Tune RandomForest hyperparameters")
     parser.add_argument('dataset', help='CSV or NPZ dataset')
     parser.add_argument('--model-out', help='Optional path to save best model')
+    parser.add_argument('--options', help='CSV with option features')
     args = parser.parse_args()
-    tune(args.dataset, args.model_out)
+    tune(args.dataset, args.model_out, args.options)
 
 
 if __name__ == '__main__':

--- a/scripts/tune_model.py
+++ b/scripts/tune_model.py
@@ -1,0 +1,60 @@
+import argparse
+import numpy as np
+import pandas as pd
+from sklearn.ensemble import RandomForestClassifier
+from sklearn.model_selection import GridSearchCV, TimeSeriesSplit
+import joblib
+from features import add_technical_indicators
+
+FEATURE_COLS = [
+    'MA_20', 'MA_50', 'EMA_20', 'EMA_50',
+    'BB_Upper', 'BB_Lower', 'MACD', 'MACD_Signal',
+    'RSI_14', 'Stoch_%K', 'Stoch_%D', 'ATR_14',
+    'CCI_20', 'OBV'
+]
+
+def load_csv(csv_path: str) -> tuple[np.ndarray, np.ndarray]:
+    df = pd.read_csv(csv_path, index_col=0, parse_dates=True)
+    df = add_technical_indicators(df)
+    df['Target'] = (df['Close'].shift(-1) > df['Close']).astype(int)
+    df.dropna(inplace=True)
+    X = df[FEATURE_COLS]
+    y = df['Target']
+    return X.values, y.values
+
+def load_npz(npz_path: str) -> tuple[np.ndarray, np.ndarray]:
+    data = np.load(npz_path)
+    return data['X'], data['y']
+
+def tune(dataset: str, save_path: str | None = None) -> None:
+    if dataset.lower().endswith('.npz'):
+        X, y = load_npz(dataset)
+    else:
+        X, y = load_csv(dataset)
+
+    param_grid = {
+        'n_estimators': [100, 200],
+        'max_depth': [None, 5, 10],
+    }
+    tscv = TimeSeriesSplit(n_splits=3)
+    model = RandomForestClassifier(random_state=42)
+    gs = GridSearchCV(model, param_grid, cv=tscv, n_jobs=-1)
+    gs.fit(X, y)
+    print(f"Best params: {gs.best_params_}")
+    print(f"Best score: {gs.best_score_:.4f}")
+
+    if save_path:
+        joblib.dump(gs.best_estimator_, save_path)
+        print(f"Saved best model to {save_path}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Tune RandomForest hyperparameters")
+    parser.add_argument('dataset', help='CSV or NPZ dataset')
+    parser.add_argument('--model-out', help='Optional path to save best model')
+    args = parser.parse_args()
+    tune(args.dataset, args.model_out)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/vectorize.py
+++ b/scripts/vectorize.py
@@ -1,0 +1,34 @@
+import argparse
+import pandas as pd
+import numpy as np
+from features import add_technical_indicators
+
+FEATURE_COLS = [
+    'MA_20', 'MA_50', 'EMA_20', 'EMA_50',
+    'BB_Upper', 'BB_Lower', 'MACD', 'MACD_Signal',
+    'RSI_14', 'Stoch_%K', 'Stoch_%D', 'ATR_14',
+    'CCI_20', 'OBV'
+]
+
+
+def vectorize(csv_path: str, output_path: str) -> None:
+    df = pd.read_csv(csv_path, index_col=0, parse_dates=True)
+    df = add_technical_indicators(df)
+    df['Target'] = (df['Close'].shift(-1) > df['Close']).astype(int)
+    df.dropna(inplace=True)
+    X = df[FEATURE_COLS].astype(np.float32).values
+    y = df['Target'].astype(np.int8).values
+    np.savez_compressed(output_path, X=X, y=y)
+    print(f"Saved {len(df)} rows to {output_path}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Vectorize price data to npz")
+    parser.add_argument('csv', help='CSV file with price data')
+    parser.add_argument('--output', default='data.npz', help='Output npz file')
+    args = parser.parse_args()
+    vectorize(args.csv, args.output)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/vectorize.py
+++ b/scripts/vectorize.py
@@ -1,19 +1,22 @@
 import argparse
 import pandas as pd
 import numpy as np
-from features import add_technical_indicators
+from features import add_technical_indicators, add_option_features, OPTION_FEATURES
 
 FEATURE_COLS = [
     'MA_20', 'MA_50', 'EMA_20', 'EMA_50',
     'BB_Upper', 'BB_Lower', 'MACD', 'MACD_Signal',
     'RSI_14', 'Stoch_%K', 'Stoch_%D', 'ATR_14',
-    'CCI_20', 'OBV'
-]
+    'CCI_20', 'OBV',
+] + OPTION_FEATURES
 
 
-def vectorize(csv_path: str, output_path: str) -> None:
+def vectorize(csv_path: str, output_path: str, options_path: str | None = None) -> None:
     df = pd.read_csv(csv_path, index_col=0, parse_dates=True)
     df = add_technical_indicators(df)
+    if options_path:
+        opt_df = pd.read_csv(options_path, index_col=0, parse_dates=True)
+        df = add_option_features(df, opt_df)
     df['Target'] = (df['Close'].shift(-1) > df['Close']).astype(int)
     df.dropna(inplace=True)
     X = df[FEATURE_COLS].astype(np.float32).values
@@ -25,9 +28,10 @@ def vectorize(csv_path: str, output_path: str) -> None:
 def main():
     parser = argparse.ArgumentParser(description="Vectorize price data to npz")
     parser.add_argument('csv', help='CSV file with price data')
+    parser.add_argument('--options', help='CSV with option features')
     parser.add_argument('--output', default='data.npz', help='Output npz file')
     args = parser.parse_args()
-    vectorize(args.csv, args.output)
+    vectorize(args.csv, args.output, args.options)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- add example Python scripts to download data, compute features, and train a basic model
- document setup and usage steps
- list dependencies in `requirements.txt`

## Testing
- `pytest -q`
- `python -m py_compile scripts/*.py`


------
https://chatgpt.com/codex/tasks/task_e_684361252714832aa863210e33feefc3